### PR TITLE
add support for INSR status register to DG645

### DIFF
--- a/delaygenApp/Db/drvDG645.db
+++ b/delaygenApp/Db/drvDG645.db
@@ -63,6 +63,15 @@ record(bo,"$(P)$(R)GotoRemoteBO")
     field(OUT,  "@asyn($(PORT)) REMOTE")
 }
 
+## Instrument event status related PVs
+record(longin,"$(P)$(R)EventStatus")
+{
+    field(DESC, "Event Status")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT)) EVENT_STATUS")
+    field(SCAN, "Passive")
+}
+
 ## Input trigger related PVs
 record(ai,"$(P)$(R)TriggerRateAI")
 {

--- a/delaygenApp/src/drvAsynDG645.cpp
+++ b/delaygenApp/src/drvAsynDG645.cpp
@@ -27,8 +27,10 @@
  Authors: David M. Kline (DMK)
           Eric Norum (EN)
           Dohn Arms (DAA)
+          John Runchey (JQR)
  -----------------------------------------------------------------------------
  History:
+ 2020-Aug-03  JQR  Add support for INSR command.
  2009-Jan-31  DMK  Derived support from drvAsynColby driver.
  2009-Feb-11  DMK  Initial development version V1.0 complete.
  2009-Feb-11  DMK  Development version V1.1 complete.
@@ -316,6 +318,9 @@ static Command commandTable[] =
   {"",         readSink,       cvtSink,        "*RCL%d",       writeIntParam,      "RECALL",          }, // "Recall Settings"},
   {"",         readSink,       cvtSink,        "*SAV%d",       writeIntParam,      "SAVE",            }, // "Save Settings"},
   
+  // Instrument event status related commands
+  {"INSR?",    readParam,      cvtStrInt,      "",             writeSink,          "EVENT_STATUS",    }, // "Instrument Event Status"},
+
   // Trigger related commands
   {"TLVL?",    readParam,      cvtStrFloat,    "TLVL%-.2f",    writeFloatParam,    "TRIG_LEVEL",      }, // "Trigger Level"},
   {"TRAT?",    readParam,      cvtStrFloat,    "TRAT%-.6f",    writeFloatParam,    "TRIG_RATE",       }, // "Trigger Rate"},


### PR DESCRIPTION
Added a db record and support in drvAsynDG645.cpp for the INSR? command that returns the event status register on the DG645